### PR TITLE
Fixed bug in setting maximum zoom

### DIFF
--- a/QMapControl/src/QMapControl/QMapControl.cpp
+++ b/QMapControl/src/QMapControl/QMapControl.cpp
@@ -1148,7 +1148,7 @@ namespace qmapcontrol
     void QMapControl::checkZoom()
     {
         // Quick check to ensure min <= max.
-        if(m_zoom_maximum > m_zoom_minimum)
+        if(m_zoom_maximum < m_zoom_minimum)
         {
             // Swap the zooms.
             std::swap(m_zoom_minimum, m_zoom_maximum);


### PR DESCRIPTION
QMapControl::setZoomMaximum(19) wasn't working properly because of wrong comparison symbol ">" in checkZoom(). 
